### PR TITLE
Not need this route in lesson 06

### DIFF
--- a/lessons/06-params.md
+++ b/lessons/06-params.md
@@ -49,7 +49,6 @@ import Repo from './modules/Repo'
 render((
   <Router>
     <Route path="/" component={App}>
-      <IndexRoute component={Home}/>
       <Route path="/repos" component={Repos}/>
       {/* add the new route */}
       <Route path="/repos/:userName/:repoName" component={Repo}/>

--- a/lessons/09-index-links.md
+++ b/lessons/09-index-links.md
@@ -44,7 +44,7 @@ We can use `Link` as well by passing it the `onlyActiveOnIndex` prop
 That's fine, but we already abstracted away having to know what the
 `activeClassName` is with `Nav`.
 
-Remember, in `Nav` we're passing along all of our props to `Link` with
+Remember, in `NavLink` we're passing along all of our props to `Link` with
 the `{...spread}` syntax, so we can actually add the prop when we render
 a `NavLink` and it will make its way down to the `Link`:
 


### PR DESCRIPTION
In Lesson 06, we did not need this route, it should be added in lesson 08.

The lesson 08 have added it as below snippet.

```
      {/* add it here, as a child of `/` */}
      <IndexRoute component={Home}/>
```