### PR TITLE
Pass default boolean value to attribute

### DIFF
--- a/lessons/09-index-links.md
+++ b/lessons/09-index-links.md
@@ -38,7 +38,7 @@ We can use `Link` as well by passing it the `onlyActiveOnIndex` prop
 (`IndexLink` just wraps `Link` with this property for convenience).
 
 ```js
-<li><Link to="/" activeClassName="active" onlyActiveOnIndex>Home</Link></li>
+<li><Link to="/" activeClassName="active" onlyActiveOnIndex={true}>Home</Link></li>
 ```
 
 That's fine, but we already abstracted away having to know what the
@@ -49,7 +49,7 @@ the `{...spread}` syntax, so we can actually add the prop when we render
 a `NavLink` and it will make its way down to the `Link`:
 
 ```js
-<li><NavLink to="/" onlyActiveOnIndex>Home</NavLink></li>
+<li><NavLink to="/" onlyActiveOnIndex={true}>Home</NavLink></li>
 ```
 
 ---


### PR DESCRIPTION
Due to the [react/jsx-boolean-value](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-boolean-value.md) eslint configuration we need to pass default boolean value. This is [common](https://github.com/facebook/react/blob/master/.eslintrc#L41) pattern and it will be better to make sure tutorial teaches users good code style.