### PR TITLE
Add NPM install to starter tutorial

### DIFF
--- a/lessons/01-setting-up.md
+++ b/lessons/01-setting-up.md
@@ -12,6 +12,7 @@ up our project.
 git clone <tutorial url>
 cd react-router-tutorial
 git checkout start
+npm install
 npm start
 ```
 


### PR DESCRIPTION
An NPM install is necessary before the `npm start` command. A no-brainer, but may be helpful for newcomers.