### PR TITLE
Adding an "npm install" to the initial instructions

### DIFF
--- a/lessons/01-setting-up.md
+++ b/lessons/01-setting-up.md
@@ -12,6 +12,7 @@ up our project.
 git clone <tutorial url>
 cd react-router-tutorial
 git checkout start
+npm install
 npm start
 ```
 


### PR DESCRIPTION
I assume the intent is for users to `npm install` before running the code, so just adding a single line here to the instructions.