### PR TITLE
Remove IndexRoute from 06-params.md

### DIFF
--- a/lessons/06-params.md
+++ b/lessons/06-params.md
@@ -49,7 +49,6 @@ import Repo from './modules/Repo'
 render((
   <Router>
     <Route path="/" component={App}>
-      <IndexRoute component={Home}/>
       <Route path="/repos" component={Repos}/>
       {/* add the new route */}
       <Route path="/repos/:userName/:repoName" component={Repo}/>


### PR DESCRIPTION
When following along sequentially, `<IndexRoute />` has not yet been covered.