### PR TITLE
Remove the use of `IndexRoute` in advance

### DIFF
--- a/lessons/06-params.md
+++ b/lessons/06-params.md
@@ -47,9 +47,8 @@ Now open up `index.js` and add the new route.
 import Repo from './modules/Repo'
 
 render((
-  <Router>
+  <Router history={hashHistory}>
     <Route path="/" component={App}>
-      <IndexRoute component={Home}/>
       <Route path="/repos" component={Repos}/>
       {/* add the new route */}
       <Route path="/repos/:userName/:repoName" component={Repo}/>


### PR DESCRIPTION
In the lesson of `URL Params`, the `IndexRoute` is not introduced. Remove it.