### PR TITLE
Add 'npm install' after cloning repo step

### DIFF
--- a/lessons/01-setting-up.md
+++ b/lessons/01-setting-up.md
@@ -12,6 +12,7 @@ up our project.
 git clone <tutorial url>
 cd react-router-tutorial
 git checkout start
+npm install
 npm start
 ```
 


### PR DESCRIPTION
This can be useful for those who don't have webpack-dev-server installed for example