### PR TITLE
13 server rendering: Delete index.html (to fetch)

### DIFF
--- a/lessons/13-server-rendering.md
+++ b/lessons/13-server-rendering.md
@@ -183,6 +183,8 @@ app.listen(PORT, function() {
 })
 ```
 
+Now delete `public/index.html` to use the server rendered version instead.
+
 And that's it. Now if you run `NODE_ENV=production npm start` and visit
 the app, you can view source and see that the server is sending down our
 app to the browser. As you click around, you'll notice the client app


### PR DESCRIPTION
Delete `public/index.html` to use server rendering rather than the filesystem for the root route.