### PR TITLE
Update to include npm install step

### DIFF
--- a/lessons/01-setting-up.md
+++ b/lessons/01-setting-up.md
@@ -12,6 +12,7 @@ up our project.
 git clone <tutorial url>
 cd react-router-tutorial
 git checkout start
+npm install
 npm start
 ```
 


### PR DESCRIPTION
If npm install is not run before npm start, webpack-dev-server reports the following: 

```
ERROR in multi main
Module not found: Error: Cannot resolve module 'babel-loader' in /<working dir>/react-router-tutorial
 @ multi main
```