### PR TITLE
10-clean-urls : Add a missing "/" on Router closing tag

### DIFF
--- a/lessons/10-clean-urls.md
+++ b/lessons/10-clean-urls.md
@@ -20,7 +20,7 @@ import { Router, Route, browserHistory, IndexRoute } from 'react-router'
 render((
   <Router history={browserHistory}>
     {/* ... */}
-  <Router>
+  </Router>
 ), document.getElementById('app'))
 ```
 
@@ -65,4 +65,3 @@ clean urls :)
 ---
 
 [Next: Production-ish Server](11-productionish-server.md)
-


### PR DESCRIPTION
Hello,

I just did the tutorial, and I think there is a missing `/` on the line 23 `</Router>`.