### PR TITLE
removes <IndexRoute> - Not needed in this lesson

### DIFF
--- a/lessons/06-params/README.md
+++ b/lessons/06-params/README.md
@@ -49,7 +49,6 @@ import Repo from './modules/Repo'
 render((
   <Router>
     <Route path="/" component={App}>
-      <IndexRoute component={Home}/>
       <Route path="/repos" component={Repos}/>
       {/* add the new route */}
       <Route path="/repos/:userName/:repoName" component={Repo}/>


### PR DESCRIPTION
Fixes #6

Removes <IndexRoute component={Home}/> which produces error (IndexRoute is not defined).
This line is not needed until lesson#8