### PR TITLE
changed direction from Repo.js to App.js

### DIFF
--- a/lessons/06-params/README.md
+++ b/lessons/06-params/README.md
@@ -58,7 +58,7 @@ render((
 ), document.getElementById('app'))
 ```
 
-Now we can add some links to this new route in `Repos.js`.
+Now we can add some links to this new route in `App.js`.
 
 ```js
 // Repos.js


### PR DESCRIPTION
Modified react-router-tutorial/lessons/06-params/README.md: 

"Now we can add some links to this new route in `Repos.js`."

To: 

"Now we can add some links to this new route in `App.js`"