### PR TITLE
Fix `listenBeforeLeavingRoute` error

### DIFF
--- a/lessons/13-server-rendering/README.md
+++ b/lessons/13-server-rendering/README.md
@@ -37,7 +37,7 @@ module.exports = {
 
   // keep node_module paths out of the bundle
   externals: fs.readdirSync(path.resolve(__dirname, 'node_modules')).concat([
-    'react-dom/server'
+    'react-dom/server', 'react/addons',
   ]).reduce(function (ext, mod) {
     ext[mod] = 'commonjs ' + mod
     return ext


### PR DESCRIPTION
I had to add 'react/addons' as external due to a `Cannot read property 'listenBeforeLeavingRoute' of undefined` error. Got it from here https://github.com/reactjs/react-router/issues/1093#issuecomment-112920555