### PR TITLE
Improve webpack server config

### DIFF
--- a/lessons/13-server-rendering/README.md
+++ b/lessons/13-server-rendering/README.md
@@ -27,21 +27,17 @@ var path = require('path')
 
 module.exports = {
 
-  entry: path.resolve(__dirname, 'server.js'),
+  entry: './server.js',
 
   output: {
-    filename: 'server.bundle.js'
+    filename: 'server.bundle.js',
+    libraryTarget: 'commonjs2'
   },
 
   target: 'node',
 
   // keep node_module paths out of the bundle
-  externals: fs.readdirSync(path.resolve(__dirname, 'node_modules')).concat([
-    'react-dom/server', 'react/addons',
-  ]).reduce(function (ext, mod) {
-    ext[mod] = 'commonjs ' + mod
-    return ext
-  }, {}),
+  externals: /^[^.]/,
 
   node: {
     __filename: true,
@@ -50,7 +46,7 @@ module.exports = {
 
   module: {
     loaders: [
-      { test: /\.js$/, exclude: /node_modules/, loader: 'babel-loader?presets[]=es2015&presets[]=react' }
+      { test: /\.js$/, loader: 'babel-loader?presets[]=es2015&presets[]=react' }
     ]
   }
 

--- a/lessons/14-whats-next/webpack.server.config.js
+++ b/lessons/14-whats-next/webpack.server.config.js
@@ -3,21 +3,17 @@ var path = require('path')
 
 module.exports = {
 
-  entry: path.resolve(__dirname, 'server.js'),
+  entry: './server.js',
 
   output: {
-    filename: 'server.bundle.js'
+    filename: 'server.bundle.js',
+    libraryTarget: 'commonjs2'
   },
 
   target: 'node',
 
   // keep node_module paths out of the bundle
-  externals: fs.readdirSync(path.resolve(__dirname, 'node_modules')).concat([
-    'react-dom/server'
-  ]).reduce(function (ext, mod) {
-    ext[mod] = 'commonjs ' + mod
-    return ext
-  }, {}),
+  externals: /^[^.]/,
 
   node: {
     __filename: false,
@@ -26,7 +22,7 @@ module.exports = {
 
   module: {
     loaders: [
-      { test: /\.js$/, exclude: /node_modules/, loader: 'babel-loader?presets[]=es2015&presets[]=react' }
+      { test: /\.js$/, loader: 'babel-loader?presets[]=es2015&presets[]=react' }
     ]
   }
 


### PR DESCRIPTION
This pull request encompasses the following four changes to the webpack server config:

1. Remove `exclude: /node_modules/` from the loader config. This is unnecessary as node_modules are externalized and thus not bundled by webpack.

2. Use a regular expression to externalize all import strings that do not begin with a `.`. This replaces the current rule which requires nested imports to be explicitly named in the webpack config. The caveat of this method is if one wishes to configure webpack to allow for non-relative imports of modules from specific directories. Those imports would not use a `.` and would be incorrectly externalized. I do not recommend configuring webpack to enable such imports. Therefore, I think this caveat is acceptable and achieves the desired behavior more elegantly and succinctly.

3. Prefix the entry file with `./` to prevent it from being externalized.

4. Add the `output.libraryTarget` property. This tells webpack to resolve external dependencies as commonjs.