### PR TITLE
Change port 8080 to 7531

### DIFF
--- a/lessons/01-setting-up/README.md
+++ b/lessons/01-setting-up/README.md
@@ -16,7 +16,7 @@ npm install
 npm start
 ```
 
-Now open up [http://localhost:8080](http://localhost:8080)
+Now open up [http://localhost:7531](http://localhost:7531)
 
 Feel free to poke around the code to see how we're using webpack and npm
 scripts to run the app.

--- a/lessons/01-setting-up/package.json
+++ b/lessons/01-setting-up/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start": "webpack-dev-server --inline --content-base ."
+    "start": "webpack-dev-server --inline --port 7531 --content-base ."
   },
   "author": "",
   "license": "ISC",

--- a/lessons/02-rendering-a-route/README.md
+++ b/lessons/02-rendering-a-route/README.md
@@ -25,7 +25,7 @@ render((
 ```
 
 Make sure your server is running with `npm start` and then visit
-[http://localhost:8080](http://localhost:8080)
+[http://localhost:7531](http://localhost:7531)
 
 You should get the same screen as before, but this time with some junk
 in the URL. We're using `hashHistory`--it manages the routing history
@@ -79,8 +79,8 @@ render((
 ), document.getElementById('app'))
 ```
 
-Now visit [http://localhost:8080/#/about](http://localhost:8080/#/about) and
-[http://localhost:8080/#/repos](http://localhost:8080/#/repos)
+Now visit [http://localhost:7531/#/about](http://localhost:7531/#/about) and
+[http://localhost:7531/#/repos](http://localhost:7531/#/repos)
 
 ---
 

--- a/lessons/02-rendering-a-route/package.json
+++ b/lessons/02-rendering-a-route/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start": "webpack-dev-server --inline --content-base ."
+    "start": "webpack-dev-server --inline --port 7531 --content-base ."
   },
   "author": "",
   "license": "ISC",

--- a/lessons/03-navigating-with-link/README.md
+++ b/lessons/03-navigating-with-link/README.md
@@ -26,7 +26,7 @@ export default React.createClass({
 })
 ```
 
-Now visit [http://localhost:8080](http://localhost:8080) and click the links, click back, click
+Now visit [http://localhost:7531](http://localhost:7531) and click the links, click back, click
 forward. It works!
 
 ---

--- a/lessons/03-navigating-with-link/package.json
+++ b/lessons/03-navigating-with-link/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start": "webpack-dev-server --inline --content-base ."
+    "start": "webpack-dev-server --inline --port 7531 --content-base ."
   },
   "author": "",
   "license": "ISC",

--- a/lessons/04-nested-routes/package.json
+++ b/lessons/04-nested-routes/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start": "webpack-dev-server --inline --content-base ."
+    "start": "webpack-dev-server --inline --port 7531 --content-base ."
   },
   "author": "",
   "license": "ISC",

--- a/lessons/05-active-links/package.json
+++ b/lessons/05-active-links/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start": "webpack-dev-server --inline --content-base ."
+    "start": "webpack-dev-server --inline --port 7531 --content-base ."
   },
   "author": "",
   "license": "ISC",

--- a/lessons/06-params/package.json
+++ b/lessons/06-params/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start": "webpack-dev-server --inline --content-base ."
+    "start": "webpack-dev-server --inline --port 7531 --content-base ."
   },
   "author": "",
   "license": "ISC",

--- a/lessons/07-more-nesting/package.json
+++ b/lessons/07-more-nesting/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start": "webpack-dev-server --inline --content-base ."
+    "start": "webpack-dev-server --inline --port 7531 --content-base ."
   },
   "author": "",
   "license": "ISC",

--- a/lessons/08-index-routes/README.md
+++ b/lessons/08-index-routes/README.md
@@ -70,7 +70,7 @@ render((
 ), document.getElementById('app'))
 ```
 
-Now open [http://localhost:8080](http://localhost:8080) and you'll see the new component is
+Now open [http://localhost:7531](http://localhost:7531) and you'll see the new component is
 rendered.
 
 Notice how the `IndexRoute` has no path. It becomes

--- a/lessons/08-index-routes/package.json
+++ b/lessons/08-index-routes/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start": "webpack-dev-server --inline --content-base ."
+    "start": "webpack-dev-server --inline --port 7531 --content-base ."
   },
   "author": "",
   "license": "ISC",

--- a/lessons/09-index-links/package.json
+++ b/lessons/09-index-links/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start": "webpack-dev-server --inline --content-base ."
+    "start": "webpack-dev-server --inline --port 7531 --content-base ."
   },
   "author": "",
   "license": "ISC",

--- a/lessons/10-clean-urls/README.md
+++ b/lessons/10-clean-urls/README.md
@@ -43,7 +43,7 @@ The Webpack Dev Server has an option to enable this. Open up
 `package.json` and add `--history-api-fallback`.
 
 ```json
-    "start": "webpack-dev-server --inline --content-base . --history-api-fallback"
+    "start": "webpack-dev-server --inline --port 7531 --content-base . --history-api-fallback"
 ```
 
 We also need to change our relative paths to absolute paths in

--- a/lessons/10-clean-urls/package.json
+++ b/lessons/10-clean-urls/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start": "webpack-dev-server --inline --content-base ."
+    "start": "webpack-dev-server --inline --port 7531 --content-base ."
   },
   "author": "",
   "license": "ISC",

--- a/lessons/11-productionish-server/README.md
+++ b/lessons/11-productionish-server/README.md
@@ -22,7 +22,7 @@ scripts entry in package.json to look like this:
 // package.json
 "scripts": {
   "start": "if-env NODE_ENV=production && npm run start:prod || npm run start:dev",
-  "start:dev": "webpack-dev-server --inline --content-base . --history-api-fallback",
+  "start:dev": "webpack-dev-server --inline --port 7531 --content-base . --history-api-fallback",
   "start:prod": "webpack && node server.js"
 },
 ```
@@ -50,7 +50,7 @@ app.get('*', function (req, res) {
   res.sendFile(path.join(__dirname, 'index.html'))
 })
 
-var PORT = process.env.PORT || 8080
+var PORT = process.env.PORT || 7531
 app.listen(PORT, function() {
   console.log('Production Express server running at localhost:' + PORT)
 })
@@ -65,7 +65,7 @@ NODE_ENV=production npm start
 ```
 
 Congratulations! You now have a production server for this app. After
-clicking around, try navigating to [http://localhost:8080/package.json](http://localhost:8080/package.json).
+clicking around, try navigating to [http://localhost:7531/package.json](http://localhost:7531/package.json).
 Whoops.  Let's fix that. We're going to shuffle around a couple files and
 update some paths scattered across the app.
 

--- a/lessons/11-productionish-server/package.json
+++ b/lessons/11-productionish-server/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start": "webpack-dev-server --inline --content-base . --history-api-fallback"
+    "start": "webpack-dev-server --inline --port 7531 --content-base . --history-api-fallback"
   },
   "author": "",
   "license": "ISC",

--- a/lessons/12-navigating/server.js
+++ b/lessons/12-navigating/server.js
@@ -14,7 +14,7 @@ app.get('*', function (req, res) {
   res.sendFile(path.join(__dirname, 'public', 'index.html'))
 })
 
-var PORT = process.env.PORT || 8080
+var PORT = process.env.PORT || 7531
 app.listen(PORT, function() {
   console.log('Production Express server running at localhost:' + PORT)
 })

--- a/lessons/13-server-rendering/README.md
+++ b/lessons/13-server-rendering/README.md
@@ -177,7 +177,7 @@ function renderPage(appHtml) {
    `
 }
 
-var PORT = process.env.PORT || 8080
+var PORT = process.env.PORT || 7531
 app.listen(PORT, function() {
   console.log('Production Express server running at localhost:' + PORT)
 })

--- a/lessons/13-server-rendering/server.js
+++ b/lessons/13-server-rendering/server.js
@@ -14,7 +14,7 @@ app.get('*', function (req, res) {
   res.sendFile(path.join(__dirname, 'public', 'index.html'))
 })
 
-var PORT = process.env.PORT || 8080
+var PORT = process.env.PORT || 7531
 app.listen(PORT, function() {
   console.log('Production Express server running at localhost:' + PORT)
 })

--- a/lessons/14-whats-next/server.js
+++ b/lessons/14-whats-next/server.js
@@ -42,7 +42,7 @@ function renderPage(appHtml) {
    `
 }
 
-var PORT = process.env.PORT || 8080
+var PORT = process.env.PORT || 7531
 app.listen(PORT, function() {
   console.log('Production Express server running at localhost:' + PORT)
 })


### PR DESCRIPTION
I guess is common to have Apache listening to port 8080, to prevent
webpack errors trying to access port 8080 I changed it to 7531.

There were several issues related to that:
https://github.com/reactjs/react-router-tutorial/issues/171
https://github.com/reactjs/react-router-tutorial/issues/164

I hope this save newcomers from port related issues