### PR TITLE
Configured 01 to  work with Babel6 and fixed webpack-dev-server conte…

### DIFF
--- a/lessons/01-setting-up/.babelrc
+++ b/lessons/01-setting-up/.babelrc
@@ -1,0 +1,3 @@
+{
+    'presets': ['es2015', 'react']
+}

--- a/lessons/01-setting-up/package.json
+++ b/lessons/01-setting-up/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start": "webpack-dev-server --inline --content-base ."
+    "start": "webpack-dev-server --inline"
   },
   "author": "",
   "license": "ISC",

--- a/lessons/01-setting-up/webpack.config.js
+++ b/lessons/01-setting-up/webpack.config.js
@@ -8,7 +8,7 @@ module.exports = {
 
   module: {
     loaders: [
-      { test: /\.js$/, exclude: /node_modules/, loader: 'babel-loader?presets[]=es2015&presets[]=react' }
+      { test: /\.js$/, exclude: /node_modules/, loader: 'babel-loader' }
     ]
   }
 }


### PR DESCRIPTION
Created a `.babelrc` containing babel presets that were originally in `webpack.config.js`;
This change prevents `npm start` from throwing babel error. The `contentBase` option was removed
from the npm start command as it prevented `bundle.js` from loading in `index.html`.