### PR TITLE
Changed code syntax in Lesson 12 Readme. Removed path.join from Server.js in Lesson 13.

### DIFF
--- a/lessons/12-navigating/README.md
+++ b/lessons/12-navigating/README.md
@@ -32,7 +32,7 @@ export default React.createClass({
           {/* add this form */}
           <li>
             <form onSubmit={this.handleSubmit}>
-              <input type="text" placeholder="userName"/> / {' '}
+              <input type="text" placeholder="userName"/>{' / '}
               <input type="text" placeholder="repo"/>{' '}
               <button type="submit">Go</button>
             </form>

--- a/lessons/13-server-rendering/server.js
+++ b/lessons/13-server-rendering/server.js
@@ -7,7 +7,7 @@ var app = express()
 app.use(compression())
 
 // serve our static stuff like index.css
-app.use(express.static(path.join(__dirname, 'public')))
+app.use(express.static(__dirname, 'public'))
 
 // send all requests to index.html so browserHistory works
 app.get('*', function (req, res) {


### PR DESCRIPTION
Very small change to some example code which I felt was slightly ambiguous because of the way github highlights jsx. 

I moved an intentional '/' inside the string because it is incorrectly highlighted in the readme on github which makes it appear to be a syntax error. 

I also removed the `path.join` from line 10 in server.js in Lesson 13. It was throwing an error because the path was not correct. In the other lessons with server.js that `path.join` does not appear to be present there. 