### PR TITLE
Lesson 11 rewrite

### DIFF
--- a/lessons/11-productionish-server/README.md
+++ b/lessons/11-productionish-server/README.md
@@ -35,7 +35,7 @@ scripts entry in package.json to look like this:
 ```
 When you run `npm start` it checks if the value of our `NODE_ENV` environment variable is
 `production`. If yes, it runs `npm run start:prod`, if not, it runs
-`npm run start:dev`. We have also added that the content-base of `start:dev` is a folder called public that we have just created.
+`npm run start:dev`. We have also added that the content-base of `start:dev` is the `public` directory that we just created.
 
 In the root directly, open up `webpack.config.js` and add the publicPath '/' as per below:
 ```

--- a/lessons/11-productionish-server/README.md
+++ b/lessons/11-productionish-server/README.md
@@ -56,18 +56,24 @@ var path = require('path')
 
 var app = express()
 
-// serve our static stuff like index.css
-app.use(express.static(__dirname))
+// serve our static stuff from the public directory
+app.use(express.static(path.join(__dirname, 'public')))
 
 // send all requests to index.html so browserHistory in React Router works
 app.get('*', function (req, res) {
-  res.sendFile(path.join(__dirname, 'index.html'))
+  res.sendFile(path.join(__dirname, 'public', 'index.html'))
 })
 
 var PORT = process.env.PORT || 8080
 app.listen(PORT, function() {
   console.log('Production Express server running at localhost:' + PORT)
 })
+```
+
+And finally (!) add it to the `--content-base` argument to `npm run start:dev` script:
+
+```json
+"start:dev": "webpack-dev-server --inline --content-base public --history-api-fallback",
 ```
 
 Now run:
@@ -78,43 +84,7 @@ NODE_ENV=production npm start
 # SET "NODE_ENV=production" && npm start
 ```
 
-Congratulations! You now have a production server for this app. After
-clicking around, try navigating to [http://localhost:8080/package.json](http://localhost:8080/package.json).
-Whoops.  Let's fix that. We're going to shuffle around a couple files and
-update some paths scattered across the app.
-
-Let's update `server.js` to point to the right directory for static
-assets:
-
-```js
-// server.js
-// ...
-// add path.join here
-app.use(express.static(path.join(__dirname, 'public')))
-
-// ...
-app.get('*', function (req, res) {
-  // and drop 'public' in the middle of here
-  res.sendFile(path.join(__dirname, 'public', 'index.html'))
-})
-```
-
-We also need to tell webpack to build to this new directory:
-
-```js
-// webpack.config.js
-// ...
-output: {
-  path: 'public',
-  // ...
-}
-```
-
-And finally (!) add it to the `--content-base` argument to `npm run start:dev` script:
-
-```json
-"start:dev": "webpack-dev-server --inline --content-base public --history-api-fallback",
-```
+Congratulations! You now have a production server for this app!
 
 If we had the time in this tutorial, we could use the `WebpackDevServer`
 API in a JavaScript file instead of the CLI in an npm script and then

--- a/lessons/11-productionish-server/README.md
+++ b/lessons/11-productionish-server/README.md
@@ -26,6 +26,9 @@ scripts entry in package.json to look like this:
   "start:prod": "webpack && node server.js"
 },
 ```
+When you run `npm start` it checks if the value of our `NODE_ENV` environment variable is
+`production`. If yes, it runs `npm run start:prod`, if not, it runs
+`npm run start:dev`.
 
 In the root directly, go open up `webpack.config.js` and add the publicPath '/' as per below:
 ```
@@ -36,10 +39,12 @@ In the root directly, go open up `webpack.config.js` and add the publicPath '/' 
     publicPath: '/'
   },
 ```
+Note that now we have designated a public folder will be the destination folder
+of the `bundle.js` file, because of this, we'll need to reorganise our files a little,
+namely:
 
-When you run `npm start` it checks if the value of our `NODE_ENV` environment variable is
-`production`. If yes, it runs `npm run start:prod`, if not, it runs
-`npm run start:dev`.
+1. make a `public` directory.
+2. Move `index.html` and `index.css` into it.
 
 Now we're ready to create a production server with Express and add a new file at root dir. Here's a
 first attempt:
@@ -78,10 +83,7 @@ clicking around, try navigating to [http://localhost:8080/package.json](http://l
 Whoops.  Let's fix that. We're going to shuffle around a couple files and
 update some paths scattered across the app.
 
-1. make a `public` directory.
-2. Move `index.html` and `index.css` into it.
-
-Now let's update `server.js` to point to the right directory for static
+Let's update `server.js` to point to the right directory for static
 assets:
 
 ```js

--- a/lessons/11-productionish-server/README.md
+++ b/lessons/11-productionish-server/README.md
@@ -9,13 +9,20 @@ Webpack dev server is not a production server. Let's make a production
 server and a little environment-aware script to boot up the right server
 depending on the environment.
 
+Firstly, we will need to move a few files around. When in production, we don't want the user to be able to navigate around our root folder and see files such as `package.json`. To combat this, we will create a new public folder and serve everything we want the user to be able to access from there.
+
+1. make a `public` directory.
+2. Move `index.html` and `index.css` into it.
+
+We now have to change a few things to work with this new `public` directory.
+
 Let's install a couple modules:
 
 ```
 npm install express if-env compression --save
 ```
 
-First, we'll use the handy `if-env` in `package.json`.  Update your
+We'll make use of the handy `if-env` in `package.json`.  Update your
 scripts entry in package.json to look like this:
 
 ```json
@@ -28,10 +35,9 @@ scripts entry in package.json to look like this:
 ```
 When you run `npm start` it checks if the value of our `NODE_ENV` environment variable is
 `production`. If yes, it runs `npm run start:prod`, if not, it runs
-`npm run start:dev`. We have also added that the content-base of `start:dev` is a folder called
-public that we will create soon.
+`npm run start:dev`. We have also added that the content-base of `start:dev` is a folder called public that we have just created.
 
-In the root directly, go open up `webpack.config.js` and add the publicPath '/' as per below:
+In the root directly, open up `webpack.config.js` and add the publicPath '/' as per below:
 ```
 // webpack.config.js
   output: {
@@ -41,11 +47,7 @@ In the root directly, go open up `webpack.config.js` and add the publicPath '/' 
   },
 ```
 We have now said a public folder will be the destination folder
-of the `bundle.js` file, because of this, we'll need to reorganise our files a little,
-namely:
-
-1. make a `public` directory.
-2. Move `index.html` and `index.css` into it.
+of the `bundle.js` file.
 
 Now we're ready to create a production server with Express! Start by adding a new file at root dir called `server.js`:
 
@@ -70,13 +72,7 @@ app.listen(PORT, function() {
 })
 ```
 
-And finally (!) add it to the `--content-base` argument to `npm run start:dev` script:
-
-```json
-"start:dev": "webpack-dev-server --inline --content-base public --history-api-fallback",
-```
-
-Now run:
+Simple enough, now run:
 
 ```sh
 NODE_ENV=production npm start

--- a/lessons/11-productionish-server/README.md
+++ b/lessons/11-productionish-server/README.md
@@ -22,13 +22,14 @@ scripts entry in package.json to look like this:
 // package.json
 "scripts": {
   "start": "if-env NODE_ENV=production && npm run start:prod || npm run start:dev",
-  "start:dev": "webpack-dev-server --inline --content-base . --history-api-fallback",
+  "start:dev": "webpack-dev-server --inline --content-base public --history-api-fallback",
   "start:prod": "webpack && node server.js"
 },
 ```
 When you run `npm start` it checks if the value of our `NODE_ENV` environment variable is
 `production`. If yes, it runs `npm run start:prod`, if not, it runs
-`npm run start:dev`.
+`npm run start:dev`. We have also added that the content-base of `start:dev` is a folder called
+public that we will create soon.
 
 In the root directly, go open up `webpack.config.js` and add the publicPath '/' as per below:
 ```
@@ -39,15 +40,14 @@ In the root directly, go open up `webpack.config.js` and add the publicPath '/' 
     publicPath: '/'
   },
 ```
-Note that now we have designated a public folder will be the destination folder
+We have now said a public folder will be the destination folder
 of the `bundle.js` file, because of this, we'll need to reorganise our files a little,
 namely:
 
 1. make a `public` directory.
 2. Move `index.html` and `index.css` into it.
 
-Now we're ready to create a production server with Express and add a new file at root dir. Here's a
-first attempt:
+Now we're ready to create a production server with Express! Start by adding a new file at root dir called `server.js`:
 
 ```js
 // server.js
@@ -59,7 +59,7 @@ var app = express()
 // serve our static stuff from the public directory
 app.use(express.static(path.join(__dirname, 'public')))
 
-// send all requests to index.html so browserHistory in React Router works
+// send all requests to public/index.html so browserHistory in React Router works
 app.get('*', function (req, res) {
   res.sendFile(path.join(__dirname, 'public', 'index.html'))
 })

--- a/lessons/11-productionish-server/README.md
+++ b/lessons/11-productionish-server/README.md
@@ -49,7 +49,7 @@ In the root directly, open up `webpack.config.js` and add the publicPath '/' as 
 We have now said a public folder will be the destination folder
 of the `bundle.js` file.
 
-Now we're ready to create a production server with Express! Start by adding a new file at root dir called `server.js`:
+Now we're ready to create a production server with Express! Add a new file in the root dir called `server.js` with the following code:
 
 ```js
 // server.js
@@ -72,7 +72,7 @@ app.listen(PORT, function() {
 })
 ```
 
-Simple enough, now run:
+Now run:
 
 ```sh
 NODE_ENV=production npm start
@@ -80,7 +80,7 @@ NODE_ENV=production npm start
 # SET "NODE_ENV=production" && npm start
 ```
 
-Congratulations! You now have a production server for this app!
+Congratulations! You now have a basic production server for this app!
 
 If we had the time in this tutorial, we could use the `WebpackDevServer`
 API in a JavaScript file instead of the CLI in an npm script and then


### PR DESCRIPTION
Lesson 11 currently has been causing some issues, when all steps are completed it works, however following the tutorial step-by-step and testing the production version of the code does not work as intended/can be confusing for students. For instance if the student actually does try to use npm start when the lesson states, the screen will just be blank. You can navigate to files like package.json, but we shouldn't break the app to show this. 

My understanding of the lesson is it wants to convey the following 2 points:
1. Demonstrate the need for a public folder to serve out of when using a production version of your code
2. Show how a sample simple production server could be created/used.

This rewrite still preserves these two aspects, but does them more directly than the current tutorial. The current tutorial takes the detour of making the user create it without the public directory, then add it and change the files again after realising that the user could access files they do not want. 

In this new version, we explain the need for a public directory from the outset and make the code changes only once. I feel it is clearer this way and achieves the same effect in less time.
