### PR TITLE
"npm start" not properly run, because of missing index.html

### DIFF
--- a/lessons/14-whats-next/public/index.html
+++ b/lessons/14-whats-next/public/index.html
@@ -1,0 +1,7 @@
+<!doctype html public="storage">
+<html>
+<meta charset=utf-8/>
+<title>My First React Router App</title>
+<link rel=stylesheet href=/index.css>
+<div id=app></div>
+<script src="/bundle.js"></script>


### PR DESCRIPTION
When I cloned repo, and run lesson 14 with "npm start", I got cannot get / message at browser.  But npm run start:prod is working.

To fix this I copied lesson 13's index.html to lesson 14. And it is working fine