### PR TITLE
[add] adds .babelrc file to fix webpack compiling error when running npm start

### DIFF
--- a/lessons/01-setting-up/.babelrc
+++ b/lessons/01-setting-up/.babelrc
@@ -1,0 +1,1 @@
+{ "presets": ["es2015", "react"] }


### PR DESCRIPTION
Without the `.babelrc` file, I am unable to successfully compile with `npm start`. Now it works. Hopefully this help others like me trying to learn react-router!