### PR TITLE
misleading webpack.config snippet code

### DIFF
--- a/lessons/11-productionish-server/README.md
+++ b/lessons/11-productionish-server/README.md
@@ -31,7 +31,6 @@ In the root directly, go open up `webpack.config.js` and add the publicPath '/' 
 ```
 // webpack.config.js
   output: {
-    path: 'public',
     filename: 'bundle.js',
     publicPath: '/'
   },


### PR DESCRIPTION
if you follow the lesson and copy the path param in the webpack config snippet code 
```
// webpack.config.js
  output: {
    path: 'public',
    filename: 'bundle.js',
    publicPath: '/'
  }
```

that will install bundle.js in the public dir but index.html isn't there yet and the script src tag of index.html is pointing to root of the dir. 
which will lead to output a weird error:
`SyntaxError: Unexpected token '<'`
because the browser somehow will replace bundle.js with index.html...
for a noob like me took me a while to figure it out...