### PR TITLE
Fixing typo in first webpack.config.js

### DIFF
--- a/lessons/11-productionish-server/README.md
+++ b/lessons/11-productionish-server/README.md
@@ -31,7 +31,7 @@ In the root directly, go open up `webpack.config.js` and add the publicPath '/' 
 ```
 // webpack.config.js
   output: {
-    path: 'public',
+    path: '',
     filename: 'bundle.js',
     publicPath: '/'
   },


### PR DESCRIPTION
The first example webpack.config.js has the publicPath set to '/' and the path set to 'public'; since Express hasn't yet been configured to serve files from 'public', that configuration prevents Express from serving index.html (which hasn't been moved yet).  Changing path to '' in that example fixes the issue at that point.