### PR TITLE
Fix export signature to es6 style

### DIFF
--- a/lessons/13-server-rendering/README.md
+++ b/lessons/13-server-rendering/README.md
@@ -94,7 +94,7 @@ import Repos from './Repos'
 import Repo from './Repo'
 import Home from './Home'
 
-module.exports = (
+export default (
   <Route path="/" component={App}>
     <IndexRoute component={Home}/>
     <Route path="/repos" component={Repos}>


### PR DESCRIPTION
(since we are using es6 imports both on client and server)
Otherwise when we are importing routes from 'modules/routes' it says that there is no default export in 'modules/routes'