### PR TITLE
Update README.md

### DIFF
--- a/lessons/11-productionish-server/README.md
+++ b/lessons/11-productionish-server/README.md
@@ -31,7 +31,6 @@ In the root directly, go open up `webpack.config.js` and add the publicPath '/' 
 ```
 // webpack.config.js
   output: {
-    path: 'public',
     filename: 'bundle.js',
     publicPath: '/'
   },


### PR DESCRIPTION
Setting `path: 'public'` on L:34 causes the demo app to not be able to find bundle.js and run as indicated on L:76. `path: 'public'` should not be set until L:106