### PR TITLE
Fix typo and readme bug

### DIFF
--- a/lessons/11-productionish-server/README.md
+++ b/lessons/11-productionish-server/README.md
@@ -31,7 +31,6 @@ In the root directly, go open up `webpack.config.js` and add the publicPath '/' 
 ```
 // webpack.config.js
   output: {
-    path: 'public',
     filename: 'bundle.js',
     publicPath: '/'
   },
@@ -78,7 +77,15 @@ clicking around, try navigating to [http://localhost:8080/package.json](http://l
 Whoops.  Let's fix that. We're going to shuffle around a couple files and
 update some paths scattered across the app.
 
-1. make a `public` directory.
+1. Make a `public` directory and update `webpack.config.js` again...
+    ```
+    //webpack.config.js
+    output: {
+        path: 'public',
+        filename: 'bundle.js',
+        publicPath: '/'
+    }
+    ```
 2. Move `index.html` and `index.css` into it.
 
 Now let's update `server.js` to point to the right directory for static

--- a/lessons/11-productionish-server/README.md
+++ b/lessons/11-productionish-server/README.md
@@ -77,15 +77,7 @@ clicking around, try navigating to [http://localhost:8080/package.json](http://l
 Whoops.  Let's fix that. We're going to shuffle around a couple files and
 update some paths scattered across the app.
 
-1. Make a `public` directory and update `webpack.config.js` again...
-    ```
-    //webpack.config.js
-    output: {
-        path: 'public',
-        filename: 'bundle.js',
-        publicPath: '/'
-    }
-    ```
+1. Make a `public` directory.
 2. Move `index.html` and `index.css` into it.
 
 Now let's update `server.js` to point to the right directory for static


### PR DESCRIPTION
On line 70 the production server can not find the bundle.js
file because webpack.config.js pushes the bundle.js into the
/public path. The result is a blank page because the
server has not been set up with the proper path of /public.
The Webpack configuration must be applied after the public
directory has been created on line 80 or once the server has
been configured to read from the public directory.